### PR TITLE
Feat/oauth kakao

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'com.google.code.gson:gson:2.9.0'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/sportsmatchingservice/auth/controller/UserController.java
+++ b/src/main/java/sportsmatchingservice/auth/controller/UserController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import sportsmatchingservice.auth.dto.UserSignupDto;
+import sportsmatchingservice.auth.dto.UserTokenDto;
 import sportsmatchingservice.auth.service.OauthKakaoService;
 import sportsmatchingservice.constant.ErrorCode;
 import sportsmatchingservice.constant.dto.ApiDataResponse;
@@ -33,6 +34,16 @@ public class UserController {
     public ApiDataResponse getOauthParams(@PathVariable("social") String social) {
         if (social.equals("kakao")){
             return ApiDataResponse.of(ErrorCode.OK, oauthKakaoService.getParameters());
+        } else {
+            return ApiDataResponse.of(ErrorCode.INTERNAL_ERROR, null);
+        }
+    }
+
+    @RequestMapping("/oauth/tokens/{social}")
+    public ApiDataResponse getUserTokenDto(@PathVariable("social") String social,String code) {
+        if (social.equals("kakao")) {
+            UserTokenDto userTokenDto = oauthKakaoService.getUserToken(code);
+            return ApiDataResponse.of(ErrorCode.OK, userTokenDto);
         } else {
             return ApiDataResponse.of(ErrorCode.INTERNAL_ERROR, null);
         }

--- a/src/main/java/sportsmatchingservice/auth/controller/UserController.java
+++ b/src/main/java/sportsmatchingservice/auth/controller/UserController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import sportsmatchingservice.auth.dto.UserSignupDto;
+import sportsmatchingservice.auth.service.OauthKakaoService;
 import sportsmatchingservice.constant.ErrorCode;
 import sportsmatchingservice.constant.dto.ApiDataResponse;
 import sportsmatchingservice.auth.service.UserService;
@@ -11,9 +12,11 @@ import sportsmatchingservice.auth.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/users")
 public class UserController {
 
     private final UserService userService;
+    private final OauthKakaoService oauthKakaoService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("")
@@ -26,4 +29,12 @@ public class UserController {
         }
     }
 
+    @GetMapping("/oauth/params/{social}")
+    public ApiDataResponse getOauthParams(@PathVariable("social") String social) {
+        if (social.equals("kakao")){
+            return ApiDataResponse.of(ErrorCode.OK, oauthKakaoService.getParameters());
+        } else {
+            return ApiDataResponse.of(ErrorCode.INTERNAL_ERROR, null);
+        }
+    }
 }

--- a/src/main/java/sportsmatchingservice/auth/domain/User.java
+++ b/src/main/java/sportsmatchingservice/auth/domain/User.java
@@ -31,7 +31,7 @@ public class User {
     private String nickname;
 
     @Setter
-    @Column(nullable = false, unique = true)
+    @Column
     private String phoneNumber;
 
     @Setter
@@ -65,6 +65,13 @@ public class User {
         this.password = password;
     }
 
+    protected User(String email, String nickname, String phoneNumber) {
+        this.email = email;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.isOauth = true;
+    }
+
     public static User of(
             String email,
             String nickname,
@@ -72,6 +79,14 @@ public class User {
             String password
     ) {
         return new User(email, nickname, phoneNumber, password);
+    }
+
+    public static User of(
+            String email,
+            String nickname,
+            String phoneNumber
+    ) {
+        return new User(email,nickname, phoneNumber);
     }
 
 }

--- a/src/main/java/sportsmatchingservice/auth/dto/OauthTokenDto.java
+++ b/src/main/java/sportsmatchingservice/auth/dto/OauthTokenDto.java
@@ -1,0 +1,24 @@
+package sportsmatchingservice.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Setter
+public class OauthTokenDto {
+
+    @JsonProperty("access_token")
+    @Getter
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    @Getter
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    @Getter
+    private String refreshToken;
+
+}

--- a/src/main/java/sportsmatchingservice/auth/dto/UserInfoOauthDto.java
+++ b/src/main/java/sportsmatchingservice/auth/dto/UserInfoOauthDto.java
@@ -1,0 +1,43 @@
+package sportsmatchingservice.auth.dto;
+
+import lombok.*;
+import sportsmatchingservice.auth.domain.User;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class UserInfoOauthDto {
+
+    private String email;
+    private String nickname;
+    private String phoneNumber;
+
+    private UserInfoOauthDto(String email, String nickname){
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+    public User toEntity() {
+        return User.of(
+                this.email, this.nickname, this.phoneNumber
+        );
+    }
+
+    static public UserInfoOauthDto of(){
+        return new UserInfoOauthDto();
+    }
+
+    static public UserInfoOauthDto of(String email, String nickname, String phoneNumber) {
+        return new UserInfoOauthDto(email, nickname, phoneNumber);
+    }
+
+    static public UserInfoOauthDto of(User user) {
+        return new UserInfoOauthDto(user.getEmail(), user.getNickname(), user.getPhoneNumber());
+    }
+
+    static public UserInfoOauthDto of(String email, String nickname) {
+        return new UserInfoOauthDto(email, nickname);
+    }
+}

--- a/src/main/java/sportsmatchingservice/auth/dto/UserSignupDto.java
+++ b/src/main/java/sportsmatchingservice/auth/dto/UserSignupDto.java
@@ -3,6 +3,7 @@ package sportsmatchingservice.auth.dto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import sportsmatchingservice.auth.domain.User;
 
 import javax.validation.constraints.Email;
@@ -10,6 +11,7 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class UserSignupDto {
 
     @NotBlank(message = "이메일을 작성해주세요.")

--- a/src/main/java/sportsmatchingservice/auth/dto/UserTokenDto.java
+++ b/src/main/java/sportsmatchingservice/auth/dto/UserTokenDto.java
@@ -1,0 +1,39 @@
+package sportsmatchingservice.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import sportsmatchingservice.auth.domain.User;
+
+@Getter
+@NoArgsConstructor
+public class UserTokenDto {
+
+    private Long id;
+    private String email;
+    private String nickname;
+
+    @Setter
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @Setter
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    private UserTokenDto(Long id, String email, String nickname){
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+    static public UserTokenDto of(User user) {
+        return new UserTokenDto(user.getId(), user.getEmail(), user.getNickname());
+    }
+
+    static public UserTokenDto of(){
+        return new UserTokenDto();
+    }
+
+}

--- a/src/main/java/sportsmatchingservice/auth/dto/UserTokenDto.java
+++ b/src/main/java/sportsmatchingservice/auth/dto/UserTokenDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import sportsmatchingservice.auth.domain.User;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -13,6 +14,7 @@ public class UserTokenDto {
     private Long id;
     private String email;
     private String nickname;
+    private List<String> roles;
 
     @Setter
     @JsonProperty("access_token")
@@ -22,14 +24,15 @@ public class UserTokenDto {
     @JsonProperty("refresh_token")
     private String refreshToken;
 
-    private UserTokenDto(Long id, String email, String nickname){
+    private UserTokenDto(Long id, String email, String nickname, List<String> roles){
         this.id = id;
         this.email = email;
         this.nickname = nickname;
+        this.roles = roles;
     }
 
     static public UserTokenDto of(User user) {
-        return new UserTokenDto(user.getId(), user.getEmail(), user.getNickname());
+        return new UserTokenDto(user.getId(), user.getEmail(), user.getNickname(), user.getRoles());
     }
 
     static public UserTokenDto of(){

--- a/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
+++ b/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
@@ -1,0 +1,43 @@
+package sportsmatchingservice.auth.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class OauthKakaoService {
+
+    @Getter
+    @Value("${social.kakao.params.clientId}")
+    private String clientId;
+
+    @Getter
+    @Value("${social.kakao.params.clientSecret}")
+    private String clientSecret;
+
+    @Getter
+    @Value("${social.kakao.path.redirectUri}")
+    private String redirectUri;
+
+    @Getter
+    @Value("${social.kakao.path.userInfoUrl}")
+    private String userInfoUrl;
+
+    @Getter
+    @Value("${social.kakao.path.tokenUrl")
+    private String tokenUrl;
+
+
+    public HashMap<String, String> getParameters() {
+        HashMap<String, String> parameters = new HashMap<String, String>();
+        parameters.put("clientId", getClientId());
+        parameters.put("redirectUri", getRedirectUri());
+        return parameters;
+    }
+
+}

--- a/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
+++ b/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
@@ -128,23 +128,23 @@ public class OauthKakaoService {
         if (optional.isPresent()) {
             User user = optional.get();
             UserTokenDto userTokenDto = UserTokenDto.of(user);
-            setTokens(user, userTokenDto);
+            setTokens(userTokenDto);
             return userTokenDto;
         } else {
             User user = userInfoOauthDto.toEntity();
             List<String> roles = authorityUtils.createRoles(user.getEmail());
             user.setRoles(roles);
             UserTokenDto userTokenDto = UserTokenDto.of(userRepository.save(user));
-            setTokens(user, userTokenDto);
+            setTokens(userTokenDto);
             return userTokenDto;
         }
     }
 
-    protected void setTokens(User user, UserTokenDto userTokenDto) {
+    protected void setTokens(UserTokenDto userTokenDto) {
         Map<String, Object> claims = new HashMap<String, Object>();
-        claims.put("username", user.getEmail());
-        claims.put("roles", user.getRoles());
-        String subject = user.getEmail();
+        claims.put("username", userTokenDto.getEmail());
+        claims.put("roles", userTokenDto.getRoles());
+        String subject = userTokenDto.getEmail();
         Date accessTokenExpiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());
         Date refreshTokenExpiration= jwtTokenizer.getTokenExpiration(jwtTokenizer.getRefreshTokenExpirationMinutes());
         String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());

--- a/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
+++ b/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
@@ -57,7 +57,7 @@ public class OauthKakaoService {
     private String userInfoUrl;
 
     @Getter
-    @Value("${social.kakao.path.tokenUrl")
+    @Value("${social.kakao.path.tokenUrl}")
     private String tokenUrl;
 
 

--- a/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
+++ b/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
@@ -1,16 +1,32 @@
 package sportsmatchingservice.auth.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import sportsmatchingservice.auth.dto.OauthTokenDto;
 
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class OauthKakaoService {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Getter
     @Value("${social.kakao.params.clientId}")
@@ -40,4 +56,26 @@ public class OauthKakaoService {
         return parameters;
     }
 
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.set("grant_type", "authorization_code");
+        params.set("client_id", getClientId());
+        params.set("redirect_uri", getRedirectUri());
+        params.set("code", code);
+        params.set("client_secret", getClientSecret());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<String> response = restTemplate
+                .postForEntity(getTokenUrl(), request, String.class);
+
+        try {
+            return objectMapper.readValue(response.getBody(), OauthTokenDto.class).getAccessToken();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 }

--- a/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
+++ b/src/main/java/sportsmatchingservice/auth/service/OauthKakaoService.java
@@ -1,5 +1,7 @@
 package sportsmatchingservice.auth.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import sportsmatchingservice.auth.dto.OauthTokenDto;
+import sportsmatchingservice.auth.dto.UserInfoOauthDto;
 
 import java.util.*;
 
@@ -77,5 +80,30 @@ public class OauthKakaoService {
             e.printStackTrace();
         }
         return null;
+    }
+
+    public UserInfoOauthDto getUserInfo(String accessToken)  {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer "+accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        String response = restTemplate
+                .postForEntity(getUserInfoUrl(), request, String.class).getBody();
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(String.valueOf(response));
+            String email = String.valueOf(jsonNode.get("kakao_account").get("email").asText());
+            String nickname = String.valueOf(jsonNode.get("kakao_account").get("profile").get("nickname").asText());
+//            String phoneNumber = String.valueOf(jsonNode.get("kakao_account").get("phone_number").asText());
+
+            return UserInfoOauthDto.of(email, nickname);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return UserInfoOauthDto.of();
     }
 }

--- a/src/main/java/sportsmatchingservice/config/JsonConfig.java
+++ b/src/main/java/sportsmatchingservice/config/JsonConfig.java
@@ -1,0 +1,20 @@
+package sportsmatchingservice.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class JsonConfig {
+
+    @Bean("objectMapper")
+    public ObjectMapper objectMapper() {
+        return Jackson2ObjectMapperBuilder.json()
+                .featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+    }
+}

--- a/src/main/java/sportsmatchingservice/config/OauthRestTemplateConfig.java
+++ b/src/main/java/sportsmatchingservice/config/OauthRestTemplateConfig.java
@@ -1,0 +1,17 @@
+package sportsmatchingservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+//import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class OauthRestTemplateConfig {
+
+    @Bean("restTemplate")
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+//        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        return restTemplate;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,14 @@ jwt:
 mail:
   address:
     admin: admin@gmail.com
+
+social:
+  kakao:
+    params:
+      clientId: 22b97acad5abe9c20aa6d5b4740fccb4
+      clientSecret: 7Qz7wEYSkZDetbVFlny97RJ3oXvOgCNj
+    path:
+      redirectUri: http://localhost:8080/users/oauth/tokens/kakao
+      userInfoUrl : https://kapi.kakao.com/v2/user/me
+      tokenUrl: https://kauth.kakao.com/oauth/token
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,10 @@ spring:
     username: sa
     password:
 
+  thymeleaf:
+    prefix: classpath:/templates/
+    sufix: .html
+
 jwt:
   secret-key: sports-matching-service-secret-key
   access-token-expiration-minutes: 30

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+
+<a class="p-2" href="https://kauth.kakao.com/oauth/authorize?client_id=22b97acad5abe9c20aa6d5b4740fccb4&redirect_uri=http://localhost:8080/users/oauth/tokens/kakao&response_type=code">
+    <h1>카카오 로그인</h1>
+</a>
+</body>
+</html>


### PR DESCRIPTION
### Summary
카카오 소셜 로그인 구현했습니다. 


### Key Changes 
- UserController : 
    - getOauthParams() : 카카오 로그인 url 생성에 필요한 인자 반환
    - getUserTokenDto : 카카오 인증 코드를 사용하여 소셜 회원가입 및 로그인 처리 
- User 도메인 수정 : IsOauth 필드 추가 및 password 제약 수정에 따른 생성자 및 of() 메소드 수정
- OauthTokenDto : 카카오 서버에서 토큰을 발급받아 사용하기 위한 dto -> 추후 수정 논의 필요
- UserInfoOauthDto : 카카오 서버에서 사용자 정보를 받아 사용하기 위한 dto ->추후 수정 논의 필요
- UserTokenDto : 최종 로그인시 반환되는 User 정보 dto
     - id, email, nickname, role, access token, refresh token 
- OauthKakaoService
    - clientId, clientSecret, redirectUri, userInfoUrl, tokenUrl : Springboot congifuration에서 가져와 사용
    - getParameters() : 카카오 로그인 url 생성에 필요한 인자 반환
    - getAccessToken() : 카카오 인증 서버로 토큰 요청 및 카카오 서버 access token 반환 
    - getUserInfo() : access token으로 사용자 정보 요청. 
    - setTokens() : userTokenDto에 저장된 정보의 유저 토큰 생성
    - getUserTokenDto : 카카오 유저의 정보 유무에 따라 토큰 발급 및 response data 생성
        - 카카오 유저 정보 있는 경우 : 토큰 발급 및 response data 생성 반환
        - 카카오 유저 정보 없는 경우 : 유저 정보 저장 및 토큰발급, response data 생성 반환


### To Reviewers
토큰 생성 방법과 소셜 로그인에 필요한 여러 파라미터 관리 방법에 논의가 필요해보입니다.
또한 카카오 서버로부터 토큰, 사용자 정보를 가져오기 위해 각각의 dto를 사용하였는데, 하나로 통일하거나 UserTokenDto를 사용하는 방법도 고려해봐야 될거같습니다.
메소드, 변수 명도 모호한 경우 멘션 부탁드립니다!


- 로그인 성공 시
```json
{
    "success": true,
    "code": 200,
    "message": "Ok",
    "data": {
        "id": 1,
        "email": "이메일",
        "nickname": "닉네임",
        "roles": [
            "USER"
        ],
        "access_token": "토큰",
        "refresh_token": "토큰"
    }
}
```
- 로그인 실패 시 ->카카오 사용자 정보가 일치하지 않는 경우는 프론트 - 카카오서버 사이에서 처리됩니다.


### Issue number
 #8 
