### PR TITLE
Feat/lookup games

### DIFF
--- a/$buildDir/generated/querydsl/sportsmatchingservice/auth/domain/QUser.java
+++ b/$buildDir/generated/querydsl/sportsmatchingservice/auth/domain/QUser.java
@@ -1,0 +1,56 @@
+package sportsmatchingservice.auth.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 905512484L;
+
+    public static final QUser user = new QUser("user");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final StringPath email = createString("email");
+
+    public final ListPath<sportsmatchingservice.game.domain.Game, sportsmatchingservice.game.domain.QGame> games = this.<sportsmatchingservice.game.domain.Game, sportsmatchingservice.game.domain.QGame>createList("games", sportsmatchingservice.game.domain.Game.class, sportsmatchingservice.game.domain.QGame.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isOauth = createBoolean("isOauth");
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath phoneNumber = createString("phoneNumber");
+
+    public final ListPath<String, StringPath> roles = this.<String, StringPath>createList("roles", String.class, StringPath.class, PathInits.DIRECT2);
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/$buildDir/generated/querydsl/sportsmatchingservice/game/domain/QGame.java
+++ b/$buildDir/generated/querydsl/sportsmatchingservice/game/domain/QGame.java
@@ -1,0 +1,77 @@
+package sportsmatchingservice.game.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QGame is a Querydsl query type for Game
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QGame extends EntityPathBase<Game> {
+
+    private static final long serialVersionUID = -2120239723L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QGame game = new QGame("game");
+
+    public final StringPath address = createString("address");
+
+    public final StringPath addressDetail = createString("addressDetail");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> currentRecruitment = createNumber("currentRecruitment", Integer.class);
+
+    public final DateTimePath<java.time.LocalDateTime> deadline = createDateTime("deadline", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> endDateTime = createDateTime("endDateTime", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> fee = createNumber("fee", Integer.class);
+
+    public final EnumPath<sportsmatchingservice.constant.Gender> gender = createEnum("gender", sportsmatchingservice.constant.Gender.class);
+
+    public final sportsmatchingservice.auth.domain.QUser host;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath info = createString("info");
+
+    public final NumberPath<Integer> minRecruitment = createNumber("minRecruitment", Integer.class);
+
+    public final NumberPath<Integer> recruitment = createNumber("recruitment", Integer.class);
+
+    public final EnumPath<sportsmatchingservice.constant.Sport> sport = createEnum("sport", sportsmatchingservice.constant.Sport.class);
+
+    public final DateTimePath<java.time.LocalDateTime> startDateTime = createDateTime("startDateTime", java.time.LocalDateTime.class);
+
+    public QGame(String variable) {
+        this(Game.class, forVariable(variable), INITS);
+    }
+
+    public QGame(Path<? extends Game> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QGame(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QGame(PathMetadata metadata, PathInits inits) {
+        this(Game.class, metadata, inits);
+    }
+
+    public QGame(Class<? extends Game> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.host = inits.isInitialized("host") ? new sportsmatchingservice.auth.domain.QUser(forProperty("host")) : null;
+    }
+
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+	ext {
+		queryDslVersion = '5.0.0'
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.4'
 	id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 	id 'java'
+	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'com.example'
@@ -12,6 +19,7 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+	querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -27,6 +35,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'com.google.code.gson:gson:2.9.0'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'
@@ -35,6 +46,21 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }
 
 tasks.named('test') {

--- a/src/main/java/sportsmatchingservice/auth/domain/User.java
+++ b/src/main/java/sportsmatchingservice/auth/domain/User.java
@@ -1,5 +1,6 @@
 package sportsmatchingservice.auth.domain;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -60,6 +61,7 @@ public class User {
     private List<String> roles = new ArrayList<>();
 
     @OneToMany(mappedBy = "host")
+    @JsonManagedReference
     private List<Game> games = new ArrayList<>();
 
     protected User(String email, String nickname, String phoneNumber, String password) {

--- a/src/main/java/sportsmatchingservice/auth/domain/User.java
+++ b/src/main/java/sportsmatchingservice/auth/domain/User.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import sportsmatchingservice.game.domain.Game;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;

--- a/src/main/java/sportsmatchingservice/auth/dto/UserBaseInfoDto.java
+++ b/src/main/java/sportsmatchingservice/auth/dto/UserBaseInfoDto.java
@@ -1,0 +1,18 @@
+package sportsmatchingservice.auth.dto;
+
+import lombok.*;
+import sportsmatchingservice.auth.domain.User;
+
+@Data
+@AllArgsConstructor
+public class UserBaseInfoDto {
+
+    private Long id;
+    private String email;
+    private String nickname;
+
+
+    public static UserBaseInfoDto of(User user){
+        return new UserBaseInfoDto(user.getId(), user.getEmail(), user.getNickname());
+    }
+}

--- a/src/main/java/sportsmatchingservice/auth/repository/GameRepository.java
+++ b/src/main/java/sportsmatchingservice/auth/repository/GameRepository.java
@@ -1,7 +1,0 @@
-package sportsmatchingservice.auth.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import sportsmatchingservice.auth.domain.Game;
-
-public interface GameRepository extends JpaRepository<Game, Long> {
-}

--- a/src/main/java/sportsmatchingservice/config/QuerydslConfig.java
+++ b/src/main/java/sportsmatchingservice/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package sportsmatchingservice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/sportsmatchingservice/game/controller/GameController.java
+++ b/src/main/java/sportsmatchingservice/game/controller/GameController.java
@@ -1,10 +1,10 @@
-package sportsmatchingservice.auth.controller;
+package sportsmatchingservice.game.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-import sportsmatchingservice.auth.dto.GamePostDto;
-import sportsmatchingservice.auth.service.GameService;
+import sportsmatchingservice.game.dto.GamePostDto;
+import sportsmatchingservice.game.service.GameService;
 import sportsmatchingservice.constant.ErrorCode;
 import sportsmatchingservice.constant.dto.ApiDataResponse;
 
@@ -30,4 +30,6 @@ public class GameController {
 
         return ApiDataResponse.of(ErrorCode.INTERNAL_ERROR, null);
     }
+
 }
+

--- a/src/main/java/sportsmatchingservice/game/controller/GameController.java
+++ b/src/main/java/sportsmatchingservice/game/controller/GameController.java
@@ -1,13 +1,19 @@
 package sportsmatchingservice.game.controller;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import sportsmatchingservice.constant.Gender;
+import sportsmatchingservice.constant.Sport;
 import sportsmatchingservice.game.dto.GamePostDto;
+import sportsmatchingservice.game.dto.GameResponseDto;
 import sportsmatchingservice.game.service.GameService;
 import sportsmatchingservice.constant.ErrorCode;
 import sportsmatchingservice.constant.dto.ApiDataResponse;
 
+import java.time.LocalDate;
+import java.util.List;
 
 
 @RestController
@@ -29,6 +35,23 @@ public class GameController {
         if (result) return ApiDataResponse.of(ErrorCode.CREATED, true);
 
         return ApiDataResponse.of(ErrorCode.INTERNAL_ERROR, null);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    public ApiDataResponse getValidGameListBySearchParams(
+            @RequestParam(value="sport", required=false) Sport sport,
+            @RequestParam(value="gender", required=false) Gender gender,
+            @RequestParam(value="game_date", required=false) @DateTimeFormat(pattern="yyyy-MM-dd") LocalDate gameDate
+    ){
+        try {
+            List<GameResponseDto> gameResponseDtos
+                    = gameService.getValidGamesFilteredBy(sport, gender, gameDate);
+
+            return ApiDataResponse.of(ErrorCode.OK, gameResponseDtos);
+        } catch (Exception e) {
+            return ApiDataResponse.of(ErrorCode.INTERNAL_ERROR, null);
+        }
     }
 
 }

--- a/src/main/java/sportsmatchingservice/game/domain/Game.java
+++ b/src/main/java/sportsmatchingservice/game/domain/Game.java
@@ -1,5 +1,6 @@
 package sportsmatchingservice.game.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,6 +24,7 @@ public class Game {
 
     @ManyToOne
     @JoinColumn(nullable = false, name = "HOST_ID")
+    @JsonBackReference
     private User host;
 
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/sportsmatchingservice/game/domain/Game.java
+++ b/src/main/java/sportsmatchingservice/game/domain/Game.java
@@ -1,8 +1,11 @@
-package sportsmatchingservice.auth.domain;
+package sportsmatchingservice.game.domain;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
+import sportsmatchingservice.auth.domain.User;
 import sportsmatchingservice.constant.Gender;
 import sportsmatchingservice.constant.Sport;
 
@@ -12,6 +15,7 @@ import java.time.LocalDateTime;
 @Setter
 @Getter
 @Entity
+@NoArgsConstructor
 public class Game {
 
     @Id
@@ -97,5 +101,7 @@ public class Game {
 
         return game;
     }
+
+
 }
 

--- a/src/main/java/sportsmatchingservice/game/domain/Game.java
+++ b/src/main/java/sportsmatchingservice/game/domain/Game.java
@@ -2,7 +2,6 @@ package sportsmatchingservice.game.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import sportsmatchingservice.auth.domain.User;
@@ -69,12 +68,16 @@ public class Game {
     @Column(nullable = false)
     private Gender gender;
 
-    protected Game(Sport sport, LocalDateTime startDateTime,
-                LocalDateTime endDateTime, String address,
-                int recruitment,
-                int minRecruitment,
-                int fee,
-                Gender gender) {
+    protected Game(
+            Sport sport,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            String address,
+            int recruitment,
+            int minRecruitment,
+            int fee,
+            Gender gender
+    ) {
         this.sport = sport;
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
@@ -85,23 +88,25 @@ public class Game {
         this.gender = gender;
     }
 
-    public static Game of(Sport sport,
-                          LocalDateTime startDateTime,
-                          LocalDateTime endDateTime,
-                          String address,
-                          String addressDetail,
-                          int recruitment,
-                          int minRecruitment,
-                          int fee,
-                          Gender gender) {
-
+    public static Game of(
+            Sport sport,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            String address,
+            String addressDetail,
+            int recruitment,
+            int minRecruitment,
+            int fee,
+            Gender gender,
+            String info
+    ) {
         Game game = new Game(sport, startDateTime, endDateTime, address, recruitment, minRecruitment, fee, gender);
 
         if (addressDetail != null) game.setAddressDetail(addressDetail);
+        if (info != null && !info.isBlank()) game.setInfo(info);
 
         return game;
     }
 
 
 }
-

--- a/src/main/java/sportsmatchingservice/game/dto/GamePostDto.java
+++ b/src/main/java/sportsmatchingservice/game/dto/GamePostDto.java
@@ -46,6 +46,9 @@ public class GamePostDto {
     @JsonProperty("gender")
     private Gender gender;
 
+    @JsonProperty("info")
+    private String info;
+
     public Game toEntity() {
         return Game.of(
                 this.sport,
@@ -56,7 +59,8 @@ public class GamePostDto {
                 this.recruitment,
                 this.minRecruitment,
                 this.fee,
-                this.gender
+                this.gender,
+                this.info
         );
     }
 }

--- a/src/main/java/sportsmatchingservice/game/dto/GamePostDto.java
+++ b/src/main/java/sportsmatchingservice/game/dto/GamePostDto.java
@@ -1,8 +1,8 @@
-package sportsmatchingservice.auth.dto;
+package sportsmatchingservice.game.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import sportsmatchingservice.auth.domain.Game;
+import sportsmatchingservice.game.domain.Game;
 import sportsmatchingservice.constant.Gender;
 import sportsmatchingservice.constant.Sport;
 
@@ -14,6 +14,7 @@ public class GamePostDto {
     @NotNull
     @JsonProperty("sport")
     private Sport sport;
+
     @NotNull
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime startDateTime;
@@ -21,7 +22,6 @@ public class GamePostDto {
     @NotNull
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime endDateTime;
-
 
     @NotNull
     @JsonProperty("address")

--- a/src/main/java/sportsmatchingservice/game/dto/GameResponseDto.java
+++ b/src/main/java/sportsmatchingservice/game/dto/GameResponseDto.java
@@ -1,0 +1,87 @@
+package sportsmatchingservice.game.dto;
+
+import lombok.*;
+import sportsmatchingservice.auth.domain.User;
+import sportsmatchingservice.auth.dto.UserBaseInfoDto;
+import sportsmatchingservice.constant.Gender;
+import sportsmatchingservice.constant.Sport;
+import sportsmatchingservice.game.domain.Game;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Data
+@NoArgsConstructor
+public class GameResponseDto {
+    private Long id;
+    private UserBaseInfoDto host;
+    private Sport sport;
+    private Gender gender;
+    private LocalDateTime startDateTime;
+    private LocalDateTime endDateTime;
+    private LocalDateTime deadline;
+    private String address;
+    private String addressDetail;
+    private int recruitment;
+    private int minRecruitment;
+    private int currentRecruitment;
+    private int fee;
+    private String info;
+
+
+    private GameResponseDto(
+            Long id,
+            User host,
+            Sport sport,
+            Gender gender,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime,
+            LocalDateTime deadline,
+            String address,
+            String addressDetail,
+            int recruitment,
+            int minRecruitment,
+            int currentRecruitment,
+            int fee,
+            String info
+    ){
+        this.id = id;
+        this.host = UserBaseInfoDto.of(host);
+        this.sport = sport;
+        this.gender = gender;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.deadline = deadline;
+        this.address = address;
+        this.addressDetail = addressDetail;
+        this.recruitment = recruitment;
+        this.minRecruitment = minRecruitment;
+        this.currentRecruitment = currentRecruitment;
+        this.fee = fee;
+        this.info = info;
+    }
+
+
+    static public GameResponseDto of(Game game) {
+        return new GameResponseDto(
+                game.getId(),
+                game.getHost(),
+                game.getSport(),
+                game.getGender(),
+                game.getStartDateTime(),
+                game.getEndDateTime(),
+                game.getDeadline(),
+                game.getAddress(),
+                game.getAddressDetail(),
+                game.getRecruitment(),
+                game.getMinRecruitment(),
+                game.getCurrentRecruitment(),
+                game.getFee(),
+                game.getInfo()
+        );
+    }
+
+
+
+}
+

--- a/src/main/java/sportsmatchingservice/game/dto/GameResponseDto.java
+++ b/src/main/java/sportsmatchingservice/game/dto/GameResponseDto.java
@@ -9,7 +9,6 @@ import sportsmatchingservice.game.domain.Game;
 
 import java.time.LocalDateTime;
 
-@Setter
 @Data
 @NoArgsConstructor
 public class GameResponseDto {

--- a/src/main/java/sportsmatchingservice/game/repository/GameRepository.java
+++ b/src/main/java/sportsmatchingservice/game/repository/GameRepository.java
@@ -1,0 +1,7 @@
+package sportsmatchingservice.game.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sportsmatchingservice.game.domain.Game;
+
+public interface GameRepository extends JpaRepository<Game, Long>, GameRepositoryCustom {
+}

--- a/src/main/java/sportsmatchingservice/game/repository/GameRepository.java
+++ b/src/main/java/sportsmatchingservice/game/repository/GameRepository.java
@@ -2,6 +2,10 @@ package sportsmatchingservice.game.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import sportsmatchingservice.game.domain.Game;
+import sportsmatchingservice.game.repository.querydsl.GameRepositoryCustom;
+
 
 public interface GameRepository extends JpaRepository<Game, Long>, GameRepositoryCustom {
 }
+
+

--- a/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustom.java
+++ b/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustom.java
@@ -1,0 +1,14 @@
+package sportsmatchingservice.game.repository.querydsl;
+
+import sportsmatchingservice.constant.Gender;
+import sportsmatchingservice.constant.Sport;
+import sportsmatchingservice.game.domain.Game;
+import sportsmatchingservice.game.dto.GameResponseDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GameRepositoryCustom {
+
+    List<Game> findBySearchParams(Sport sport, Gender gender, LocalDate gameDate);
+}

--- a/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustom.java
+++ b/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustom.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 public interface GameRepositoryCustom {
 
-    List<Game> findBySearchParams(Sport sport, Gender gender, LocalDate gameDate);
+    List<Game> findValidGamesBySearchParams(Sport sport, Gender gender, LocalDate gameDate);
 }

--- a/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
+++ b/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
@@ -9,6 +9,8 @@ import sportsmatchingservice.constant.Sport;
 import sportsmatchingservice.game.domain.Game;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static sportsmatchingservice.game.domain.QGame.game;
@@ -35,12 +37,18 @@ public class GameRepositoryCustomImpl implements GameRepositoryCustom {
         if (gender != null) {
             builder.and(game.gender.eq(gender));
         }
+        if (gameDate != null) {
+            builder.and(game.startDateTime.between(
+                    gameDate.atStartOfDay(),
+                    gameDate.plusDays(1).atStartOfDay()));
+        } else {
+            builder.and(game.startDateTime.after(
+                    LocalDateTime.now(ZoneId.of("Asia/Seoul"))));
+        }
 
-        List<Game> games =  query.selectFrom(game)
+        return query.selectFrom(game)
                 .where(builder)
                 .fetch();
-
-        return games;
     }
 
 }

--- a/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
+++ b/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
@@ -1,0 +1,46 @@
+package sportsmatchingservice.game.repository.querydsl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+import sportsmatchingservice.constant.Gender;
+import sportsmatchingservice.constant.Sport;
+import sportsmatchingservice.game.domain.Game;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static sportsmatchingservice.game.domain.QGame.game;
+
+
+@Repository
+@AllArgsConstructor
+public class GameRepositoryCustomImpl implements GameRepositoryCustom {
+
+    private final JPAQueryFactory query;
+
+
+    @Override
+    public List<Game> findBySearchParams(
+            Sport sport,
+            Gender gender,
+            LocalDate gameDate
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (sport != null) {
+            builder.and(game.sport.eq(sport));
+        }
+        if (gender != null) {
+            builder.and(game.gender.eq(gender));
+        }
+
+        List<Game> games =  query.selectFrom(game)
+                .where(builder)
+                .fetch();
+
+        return games;
+    }
+
+}

--- a/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
+++ b/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
@@ -22,7 +22,7 @@ public class GameRepositoryCustomImpl implements GameRepositoryCustom {
 
 
     @Override
-    public List<Game> findBySearchParams(
+    public List<Game> findValidGamesBySearchParams(
             Sport sport,
             Gender gender,
             LocalDate gameDate

--- a/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
+++ b/src/main/java/sportsmatchingservice/game/repository/querydsl/GameRepositoryCustomImpl.java
@@ -48,6 +48,7 @@ public class GameRepositoryCustomImpl implements GameRepositoryCustom {
 
         return query.selectFrom(game)
                 .where(builder)
+                .orderBy(game.startDateTime.asc())
                 .fetch();
     }
 

--- a/src/main/java/sportsmatchingservice/game/service/GameService.java
+++ b/src/main/java/sportsmatchingservice/game/service/GameService.java
@@ -3,13 +3,19 @@ package sportsmatchingservice.game.service;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sportsmatchingservice.constant.Gender;
+import sportsmatchingservice.constant.Sport;
 import sportsmatchingservice.game.domain.Game;
 import sportsmatchingservice.auth.domain.User;
 import sportsmatchingservice.game.dto.GamePostDto;
+import sportsmatchingservice.game.dto.GameResponseDto;
 import sportsmatchingservice.game.repository.GameRepository;
 import sportsmatchingservice.auth.repository.UserRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Transactional
 @Service
@@ -39,5 +45,14 @@ public class GameService {
 
         return true;
     }
-    
+
+    public List<GameResponseDto> getValidGamesFilteredBy(Sport sport, Gender gender, LocalDate gameDate){
+
+        List<GameResponseDto> gameResponseDtos = gameRepository.findBySearchParams(sport, gender, gameDate)
+                .stream()
+                .map(game -> GameResponseDto.of(game))
+                .collect(Collectors.toList());
+
+        return gameResponseDtos;
+    }
 }

--- a/src/main/java/sportsmatchingservice/game/service/GameService.java
+++ b/src/main/java/sportsmatchingservice/game/service/GameService.java
@@ -48,7 +48,7 @@ public class GameService {
 
     public List<GameResponseDto> getValidGamesFilteredBy(Sport sport, Gender gender, LocalDate gameDate){
 
-        List<GameResponseDto> gameResponseDtos = gameRepository.findBySearchParams(sport, gender, gameDate)
+        List<GameResponseDto> gameResponseDtos = gameRepository.findValidGamesBySearchParams(sport, gender, gameDate)
                 .stream()
                 .map(game -> GameResponseDto.of(game))
                 .collect(Collectors.toList());

--- a/src/main/java/sportsmatchingservice/game/service/GameService.java
+++ b/src/main/java/sportsmatchingservice/game/service/GameService.java
@@ -1,12 +1,12 @@
-package sportsmatchingservice.auth.service;
+package sportsmatchingservice.game.service;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sportsmatchingservice.auth.domain.Game;
+import sportsmatchingservice.game.domain.Game;
 import sportsmatchingservice.auth.domain.User;
-import sportsmatchingservice.auth.dto.GamePostDto;
-import sportsmatchingservice.auth.repository.GameRepository;
+import sportsmatchingservice.game.dto.GamePostDto;
+import sportsmatchingservice.game.repository.GameRepository;
 import sportsmatchingservice.auth.repository.UserRepository;
 
 import java.util.Optional;
@@ -39,4 +39,5 @@ public class GameService {
 
         return true;
     }
+    
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
 
   datasource:
     url: jdbc:h2:~/data/sms.db;NON_KEYWORDS=USER


### PR DESCRIPTION
### Summary
Game 조회 기능 구현


### Key Changes 
- QueryDsl 적용 
- findValidGamesBySearchParams()
    -  스포츠 종목, 날짜, 성별에 따라 조회할 수 있도록 구현
    - request param이 없는 경우 모든 정보 조회(단, 현재 시간 기준으로 진행되지 않는 경기만)
- UserBaseInfoDto : 사용자의 기본 정보를 조회하기 위한 dto 구현
- GameResponseDto : 경기 정보 조회시 사용할 dto 구현

### To Reviewers
경기 생성 dto에 info 필드가 없어서 누락된거 같아서 임의대로 추가하였습니다. 
경기 정보 조회시 유저에 관한 모든 정보가 전달되는 것을 막기 위해 임의대로 UserBaseInfoDto를 구현하였습니다.
id, email, nickname만 우선 전달하도록 구현했습니다. 


### Issue number
#15
